### PR TITLE
[fix] uggly password not randomly generated

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -14,7 +14,7 @@
  * This is needed for cookie based authentication to encrypt password in
  * cookie
  */
-$cfg['blowfish_secret'] = 'a8b7c6d'; /* YOU MUST FILL IN THIS FOR COOKIE AUTH! */
+$cfg['blowfish_secret'] = 'YNH_COOKIE_PASSWD'; /* YOU MUST FILL IN THIS FOR COOKIE AUTH! */
 
 /*
  * Servers configuration

--- a/scripts/install
+++ b/scripts/install
@@ -33,6 +33,7 @@ sudo cp  -r ../phpMyAdmin-$version-all-languages/* $final_path
 echo "Setting up database..."
 db_user=phpmyadmin
 db_pwd=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d 'A-Za-z0-9' | sed -n 's/\(.\{24\}\).*/\1/p')
+cookie_pwd=$(dd if=/dev/urandom bs=1 count=200 2> /dev/null | tr -c -d 'A-Za-z0-9' | sed -n 's/\(.\{24\}\).*/\1/p')
 sed -i "s@YNH_PMA_USER@$db_user@g" ../conf/create_db.sql
 sudo yunohost app initdb $db_user -p $db_pwd
 mysql -u root -p$(sudo cat /etc/yunohost/mysql) < ../conf/create_db.sql
@@ -46,6 +47,7 @@ sed -i "s@YNH_DOMAIN@$domain@g" ../conf/config.inc.php
 sed -i "s@YNH_PMA_USER@$db_user@g" ../conf/config.inc.php
 sed -i "s@YNH_PMA_PASSWORD@$db_pwd@g" ../conf/config.inc.php
 sed -i "s@YNH_MYSQL_ROOT_PASSWORD@$(sudo cat /etc/yunohost/mysql)@g" ../conf/config.inc.php
+sed -i "s@YNH_COOKIE_PASSWORD@$cookie_pwd@g" ../conf/config.inc.php
 sudo cp ../conf/config.inc.php $final_path
 
 sudo yunohost app addaccess phpmyadmin -u $admin

--- a/scripts/install
+++ b/scripts/install
@@ -47,7 +47,7 @@ sed -i "s@YNH_DOMAIN@$domain@g" ../conf/config.inc.php
 sed -i "s@YNH_PMA_USER@$db_user@g" ../conf/config.inc.php
 sed -i "s@YNH_PMA_PASSWORD@$db_pwd@g" ../conf/config.inc.php
 sed -i "s@YNH_MYSQL_ROOT_PASSWORD@$(sudo cat /etc/yunohost/mysql)@g" ../conf/config.inc.php
-sed -i "s@YNH_COOKIE_PASSWORD@$cookie_pwd@g" ../conf/config.inc.php
+sed -i "s@YNH_COOKIE_PASSWD@$cookie_pwd@g" ../conf/config.inc.php
 sudo cp ../conf/config.inc.php $final_path
 
 sudo yunohost app addaccess phpmyadmin -u $admin


### PR DESCRIPTION
I found in the config file that there were an encryption key for cookies that needs to be randomly generated, fixed. An attacker could retrieve the plain text cookie if he knows the encryption key.