### PR TITLE
Import databases bigger than 2M in standard

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -5,6 +5,7 @@ location YNH_WWW_PATH {
   }
   index index.php;
   try_files $uri $uri/ index.php;
+  client_max_body_size 50M;
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
     fastcgi_pass unix:/var/run/php5-fpm.sock;


### PR DESCRIPTION
This fix would let us import bigger database while restoring a backup for example.

We could put bigger value, but this is already a nice step forward without compromising security, I guess.