### PR TITLE
Add upgrade from a previous commit

### DIFF
--- a/check_process
+++ b/check_process
@@ -11,6 +11,7 @@
 		setup_private=0
 		setup_public=0
 		upgrade=1
+		upgrade=1	from_commit=09ad01673cdfb9f893c138d92fce3bc965f5f8ed
 		backup_restore=1
 		multi_instance=0
 		incorrect_path=1
@@ -31,3 +32,7 @@
 ;;; Options
 Email=
 Notification=none
+;;; Upgrade options
+	; commit=09ad01673cdfb9f893c138d92fce3bc965f5f8ed
+		name=Force php5 for composer
+		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&


### PR DESCRIPTION
## Problem
- *Test an upgrade for each PR is boring...*

## Solution
- *Add a test "Upgrade from commit" in the check_process*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : frju365
- [x] **Approval (LGTM)** : Josué
- [x] **Approval (LGTM)** : frju365
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/phpmyadmin_ynh%20Add-upgrade-from-a-previous-commit%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/phpmyadmin_ynh%20Add-upgrade-from-a-previous-commit%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.